### PR TITLE
renovate implementation

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -42,24 +42,3 @@ jobs:
           python manage.py migrate --noinput
           python manage.py test --noinput
 
-  build-image:
-    runs-on: ubuntu-latest
-    needs: test
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push image (dev)
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/vigar:dev-latest
-            ghcr.io/${{ github.repository_owner }}/vigar:dev-${{ github.sha }}

--- a/.github/workflows/dev-docker-publish.yml
+++ b/.github/workflows/dev-docker-publish.yml
@@ -1,0 +1,37 @@
+name: Publish Docker (dev)
+
+on:
+  workflow_run:
+    workflows: ["CI (dev)"]
+    types:
+      - completed
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'dev' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push image (dev)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/vigar:dev-latest
+            ghcr.io/${{ github.repository_owner }}/vigar:dev-${{ github.event.workflow_run.head_sha }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -17,6 +17,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Scan for critical vulnerabilities (Trivy)
+        uses: aquasecurity/trivy-action@0.24.0
+        with:
+          scan-type: fs
+          scanners: vuln
+          ignore-unfixed: true
+          severity: CRITICAL
+          exit-code: '1'
+          format: table
+          hide-progress: true
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@v40.2.7
         with:


### PR DESCRIPTION
This pull request restructures the CI workflow for building and publishing Docker images and adds a security scan to the Renovate workflow. The main changes are the removal of the Docker image build step from the main dev CI workflow, the introduction of a dedicated workflow for publishing dev Docker images, and the addition of a critical vulnerability scan to the Renovate job.

**CI/CD Workflow Restructuring:**

* Removed the `build-image` job from `.github/workflows/dev-ci.yml`, so dev Docker images are no longer built and pushed as part of the main CI pipeline.
* Added a new workflow `.github/workflows/dev-docker-publish.yml` that triggers on successful completion of the dev CI workflow, and is responsible for building and publishing the dev Docker image to the GitHub Container Registry. This workflow ensures images are only published after successful tests on the `dev` branch.

**Security Improvements:**

* Added a Trivy vulnerability scan step to the Renovate workflow (`.github/workflows/renovate.yml`) to check for critical vulnerabilities in the file system before running Renovate. The scan will fail the job if any critical vulnerabilities are found.