### PR TITLE
Feature branch 1

### DIFF
--- a/.github/workflows/dev-docker-publish.yml
+++ b/.github/workflows/dev-docker-publish.yml
@@ -1,10 +1,9 @@
 name: Publish Docker (dev)
 
 on:
-  workflow_run:
-    workflows: ["CI (dev)"]
-    types:
-      - completed
+  pull_request:
+    branches: [ dev ]
+    types: [ closed ]
 
 permissions:
   contents: read
@@ -12,13 +11,13 @@ permissions:
 
 jobs:
   publish:
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'dev' }}
+  if: ${{ github.event.pull_request.merged == true }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+      ref: ${{ github.event.pull_request.merge_commit_sha }}
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -52,11 +51,5 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/${{ github.repository_owner }}/vigar:dev-latest
-            ghcr.io/${{ github.repository_owner }}/vigar:dev-${{ github.event.workflow_run.head_sha }}
+            ghcr.io/${{ github.repository_owner }}/vigar:dev-${{ github.event.pull_request.merge_commit_sha }}
             ghcr.io/${{ github.repository_owner }}/vigar:dev-${{ steps.extract_version.outputs.version }}
-      - name: Smoke test (staging)
-        if: ${{ secrets.STAGING_URL != '' }}
-        env:
-          STAGING_URL: ${{ secrets.STAGING_URL }}
-        run: |
-          curl -fsS "$STAGING_URL/api/health/" | jq . || (echo "Smoke test failed" && exit 1)

--- a/.github/workflows/dev-docker-publish.yml
+++ b/.github/workflows/dev-docker-publish.yml
@@ -11,13 +11,13 @@ permissions:
 
 jobs:
   publish:
-  if: ${{ github.event.pull_request.merged == true }}
+    if: ${{ github.event.pull_request.merged == true }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-      ref: ${{ github.event.pull_request.merge_commit_sha }}
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
       - name: Setup Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
This pull request updates the workflow for publishing the dev Docker image to trigger on pull request merges to the `dev` branch, rather than on the completion of the CI workflow. It also updates how tags are generated and removes the staging smoke test step.

**Workflow trigger and logic changes:**

* Changed the workflow trigger from `workflow_run` (after successful CI) to `pull_request` events of type `closed` on the `dev` branch, and updated the job condition to only run when the pull request is merged.
* Updated references in the workflow to use `github.event.pull_request.merge_commit_sha` instead of `github.event.workflow_run.head_sha` for checking out code and tagging Docker images. [[1]](diffhunk://#diff-b28e5550ea606d348b4c68a3dab23b982f488476d9431acf43903858dbd7b629L4-R20) [[2]](diffhunk://#diff-b28e5550ea606d348b4c68a3dab23b982f488476d9431acf43903858dbd7b629L55-L62)

**Removal of smoke test:**

* Removed the "Smoke test (staging)" step, which previously checked the health of the staging environment after publishing the Docker image.