### PR TITLE
indedation fix

### DIFF
--- a/.github/workflows/dev-docker-publish.yml
+++ b/.github/workflows/dev-docker-publish.yml
@@ -1,27 +1,30 @@
-name: Publish Docker (dev)
+name: Docker (dev)
 
 on:
   pull_request:
     branches: [ dev ]
-    types: [ closed ]
+    types: [ opened, synchronize, reopened, ready_for_review ]
+  push:
+    branches: [ dev ]
 
 permissions:
   contents: read
   packages: write
 
 jobs:
-  publish:
-    if: ${{ github.event.pull_request.merged == true }}
+  # ✅ Ovaj job se vrti NA PR-u i služi kao required check (nema push)
+  build-check:
+    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+
       - name: Extract version (semver)
         id: extract_version
         shell: bash
@@ -35,21 +38,68 @@ jobs:
           PY
           )
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-      - name: Set up Docker Buildx.
+
+      - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Login to GitHub Container Registry
+
+      # Nije potreban login jer ne pushamo
+      - name: Build (no push) — PR check
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          # Brži check: samo amd64 da PR ne visi dugo (možeš staviti i arm64 ako baš treba)
+          platforms: linux/amd64
+          # Korištenje cache-a da check bude što brži
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # 🚀 Ovaj job ide TEK nakon mergea (push na dev) i radi pravi multi-arch push
+  publish:
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/dev') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Extract version (semver)
+        id: extract_version
+        shell: bash
+        run: |
+          VERSION=$(python - <<'PY'
+          import io, re
+          with io.open('Vigar/settings.py', 'r', encoding='utf-8') as f:
+            s = f.read()
+          m = re.search(r'VERSION"\s*:\s*"([^"]+)"', s)
+          print(m.group(1) if m else '0.0.0')
+          PY
+          )
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and push image (dev)
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           tags: |
             ghcr.io/${{ github.repository_owner }}/vigar:dev-latest
-            ghcr.io/${{ github.repository_owner }}/vigar:dev-${{ github.event.pull_request.merge_commit_sha }}
+            ghcr.io/${{ github.repository_owner }}/vigar:dev-${{ github.sha }}
             ghcr.io/${{ github.repository_owner }}/vigar:dev-${{ steps.extract_version.outputs.version }}


### PR DESCRIPTION
This pull request updates the `.github/workflows/dev-docker-publish.yml` workflow to improve the Docker build and publish process for the `dev` branch. The main changes split the workflow into two jobs: one for PR checks (build only, no push) and another for publishing images after a push to `dev`. The workflow now also improves caching, version extraction, and multi-architecture support.

**Workflow restructuring and logic:**

* Split the workflow into two jobs: `build-check` runs on pull requests for fast, required checks (builds but does not push), and `publish` runs only on pushes to `dev` to build and push multi-arch Docker images.

**Build and publish process improvements:**

* Added caching (`cache-from` and `cache-to`) to both jobs to speed up builds. [[1]](diffhunk://#diff-b28e5550ea606d348b4c68a3dab23b982f488476d9431acf43903858dbd7b629L1-R69) [[2]](diffhunk://#diff-b28e5550ea606d348b4c68a3dab23b982f488476d9431acf43903858dbd7b629L38-R104)
* Updated the image tagging in the publish job to use `${{ github.sha }}` and extracted version, instead of the PR merge commit SHA.
* Ensured the publish job logs in to GHCR before pushing images, and clarified step names for better readability.

**Version extraction:**

* Added a Python-based step to extract the semantic version from `Vigar/settings.py` for use in Docker image tags.

**Platform support:**

* The PR check job builds only for `linux/amd64` for speed, while the publish job builds and pushes multi-arch images (`linux/amd64`, `linux/arm64`). [[1]](diffhunk://#diff-b28e5550ea606d348b4c68a3dab23b982f488476d9431acf43903858dbd7b629L1-R69) [[2]](diffhunk://#diff-b28e5550ea606d348b4c68a3dab23b982f488476d9431acf43903858dbd7b629L38-R104)