### PR TITLE
fix for docker build and publish

### DIFF
--- a/.github/workflows/dev-docker-publish.yml
+++ b/.github/workflows/dev-docker-publish.yml
@@ -37,12 +37,8 @@ jobs:
           context: .
           push: false
           platforms: linux/amd64
-          cache-from: |
-            type=registry,ref=${{ env.IMAGE_NAME }}:cache
-            type=gha
-          cache-to: |
-            type=registry,ref=${{ env.IMAGE_NAME }}:cache,mode=max
-            type=gha,mode=max
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           provenance: false
           sbom: false
 
@@ -76,14 +72,14 @@ jobs:
           push: true
           platforms: linux/amd64
           cache-from: |
-            type=registry,ref=${{ env.IMAGE_NAME }}:cache
+            type=registry,ref=ghcr.io/${{ github.repository_owner }}/vigar:cache
             type=gha
           cache-to: |
-            type=registry,ref=${{ env.IMAGE_NAME }}:cache,mode=max
+            type=registry,ref=ghcr.io/${{ github.repository_owner }}/vigar:cache,mode=max
             type=gha,mode=max
           provenance: false
           sbom: false
           tags: |
-            ${{ env.IMAGE_NAME }}:dev-latest
-            ${{ env.IMAGE_NAME }}:dev-${{ github.sha }}
-            ${{ env.IMAGE_NAME }}:dev-${{ steps.extract_version.outputs.version }}
+            ghcr.io/${{ github.repository_owner }}/vigar:dev-latest
+            ghcr.io/${{ github.repository_owner }}/vigar:dev-${{ github.sha }}
+            ghcr.io/${{ github.repository_owner }}/vigar:dev-${{ steps.extract_version.outputs.version }}

--- a/.github/workflows/dev-docker-publish.yml
+++ b/.github/workflows/dev-docker-publish.yml
@@ -11,78 +11,56 @@ permissions:
   contents: read
   packages: write
 
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/vigar
+
 jobs:
-  # ✅ Ovaj job se vrti NA PR-u i služi kao required check (nema push)
+  # ✅ Required check na PR-u (nema push)
   build-check:
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
+      - uses: actions/checkout@v4
 
       - name: Extract version (semver)
         id: extract_version
         shell: bash
         run: |
-          VERSION=$(python - <<'PY'
-          import io, re
-          with io.open('Vigar/settings.py', 'r', encoding='utf-8') as f:
-            s = f.read()
-          m = re.search(r'VERSION"\s*:\s*"([^"]+)"', s)
-          print(m.group(1) if m else '0.0.0')
-          PY
-          )
+          VERSION=$(grep -Po 'VERSION"\s*:\s*"\K[^"]+' Vigar/settings.py || echo "0.0.0")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v3
 
-      # Nije potreban login jer ne pushamo
-      - name: Build (no push) — PR check
+      - name: Build (no push) — PR check (amd64)
         uses: docker/build-push-action@v6
         with:
           context: .
           push: false
-          # Brži check: samo amd64 da PR ne visi dugo (možeš staviti i arm64 ako baš treba)
           platforms: linux/amd64
-          # Korištenje cache-a da check bude što brži
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: |
+            type=registry,ref=${{ env.IMAGE_NAME }}:cache
+            type=gha
+          cache-to: |
+            type=registry,ref=${{ env.IMAGE_NAME }}:cache,mode=max
+            type=gha,mode=max
+          provenance: false
+          sbom: false
 
-  # 🚀 Ovaj job ide TEK nakon mergea (push na dev) i radi pravi multi-arch push
+  # 🚀 Nakon mergea u dev — pravi publish (amd64)
   publish:
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/dev') }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
+      - uses: actions/checkout@v4
 
       - name: Extract version (semver)
         id: extract_version
         shell: bash
         run: |
-          VERSION=$(python - <<'PY'
-          import io, re
-          with io.open('Vigar/settings.py', 'r', encoding='utf-8') as f:
-            s = f.read()
-          m = re.search(r'VERSION"\s*:\s*"([^"]+)"', s)
-          print(m.group(1) if m else '0.0.0')
-          PY
-          )
+          VERSION=$(grep -Po 'VERSION"\s*:\s*"\K[^"]+' Vigar/settings.py || echo "0.0.0")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v3
 
       - name: Login to GHCR
         uses: docker/login-action@v3
@@ -91,15 +69,21 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push image (dev)
+      - name: Build & Push image (dev, amd64)
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          platforms: linux/amd64
+          cache-from: |
+            type=registry,ref=${{ env.IMAGE_NAME }}:cache
+            type=gha
+          cache-to: |
+            type=registry,ref=${{ env.IMAGE_NAME }}:cache,mode=max
+            type=gha,mode=max
+          provenance: false
+          sbom: false
           tags: |
-            ghcr.io/${{ github.repository_owner }}/vigar:dev-latest
-            ghcr.io/${{ github.repository_owner }}/vigar:dev-${{ github.sha }}
-            ghcr.io/${{ github.repository_owner }}/vigar:dev-${{ steps.extract_version.outputs.version }}
+            ${{ env.IMAGE_NAME }}:dev-latest
+            ${{ env.IMAGE_NAME }}:dev-${{ github.sha }}
+            ${{ env.IMAGE_NAME }}:dev-${{ steps.extract_version.outputs.version }}


### PR DESCRIPTION
This pull request improves the Docker build process and the related GitHub Actions workflow for publishing the Docker image. The main focus is on optimizing dependency installation, reducing image size, and improving caching and tagging. The changes also simplify and speed up the CI checks and the image build/publish process.

**Dockerfile improvements:**

* Refactored the `Dockerfile` to use a multi-stage build: dependencies are built as wheels in a builder stage, and only the necessary files are copied into the runtime image, resulting in a smaller, more secure image. Compiler and build tools are excluded from the final image.
* Switched to installing dependencies from prebuilt wheels, eliminating the need for compilers or APT packages in the runtime image.

**GitHub Actions workflow enhancements:**

* Improved Docker cache usage in `.github/workflows/dev-docker-publish.yml` by leveraging registry-based cache and GitHub Actions cache for faster builds and PR checks. [[1]](diffhunk://#diff-b28e5550ea606d348b4c68a3dab23b982f488476d9431acf43903858dbd7b629R14-R63) [[2]](diffhunk://#diff-b28e5550ea606d348b4c68a3dab23b982f488476d9431acf43903858dbd7b629L94-R89)
* Simplified the version extraction step by replacing the Python script with a `grep` command, making the workflow faster and easier to maintain.
* Standardized image tagging using the new `IMAGE_NAME` environment variable and updated all references accordingly for consistency. [[1]](diffhunk://#diff-b28e5550ea606d348b4c68a3dab23b982f488476d9431acf43903858dbd7b629R14-R63) [[2]](diffhunk://#diff-b28e5550ea606d348b4c68a3dab23b982f488476d9431acf43903858dbd7b629L94-R89)
* Limited the build and publish jobs to only the `amd64` architecture for now, making builds faster and more reliable. [[1]](diffhunk://#diff-b28e5550ea606d348b4c68a3dab23b982f488476d9431acf43903858dbd7b629R14-R63) [[2]](diffhunk://#diff-b28e5550ea606d348b4c68a3dab23b982f488476d9431acf43903858dbd7b629L94-R89)