### PR TITLE
Production docker publish fix

### DIFF
--- a/.github/workflows/prod-docker-publish.yml
+++ b/.github/workflows/prod-docker-publish.yml
@@ -19,15 +19,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
       - name: Extract version (semver)
         id: extract_version
         shell: bash
         run: |
-          VERSION=$(python -c "import io,re; s=io.open('Vigar/settings.py','r',encoding='utf-8').read(); m=re.search(r'VERSION\"\\s*:\\s*\"([^\"]+)\"', s); print(m.group(1) if m else '0.0.0')")
+          VERSION=$(grep -Po 'VERSION"\s*:\s*"\K[^"]+' Vigar/settings.py || echo "0.0.0")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -42,14 +38,19 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
+          cache-from: |
+            type=registry,ref=ghcr.io/${{ github.repository_owner }}/vigar:cache
+            type=registry,ref=ghcr.io/${{ github.repository_owner }}/vigar:prod-latest
+            type=gha
+          cache-to: |
+            type=registry,ref=ghcr.io/${{ github.repository_owner }}/vigar:cache,mode=max
+            type=gha,mode=max
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
+          provenance: false
+          sbom: false
           tags: |
             ghcr.io/${{ github.repository_owner }}/vigar:prod-latest
             ghcr.io/${{ github.repository_owner }}/vigar:prod-${{ github.event.workflow_run.head_sha }}
             ghcr.io/${{ github.repository_owner }}/vigar:prod-${{ steps.extract_version.outputs.version }}
-      - name: Smoke test (production)
-        if: ${{ env.PROD_URL != '' }}
-        env:
-          PROD_URL: ${{ secrets.PROD_URL }}
-        run: |
-          curl -fsS "$PROD_URL/api/health/" | jq . || (echo "Smoke test failed" && exit 1)

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -16,15 +16,19 @@ jobs:
     name: Run Renovate
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout (workflow_run)
+        if: ${{ github.event_name == 'workflow_run' }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+      - name: Checkout (manual)
+        if: ${{ github.event_name != 'workflow_run' }}
         uses: actions/checkout@v4
       - name: Scan for critical vulnerabilities (Trivy)
         if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'dev' }}
         uses: aquasecurity/trivy-action@0.24.0
         with:
           scan-type: fs
-            with:
-              ref: ${{ github.event.workflow_run.head_sha }}
           scanners: vuln
           ignore-unfixed: true
           severity: CRITICAL

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 COPY requirements.txt /app/requirements.txt
 
-# Pre-build wheels for all dependencies (uses prebuilt wheels where available, e.g. psycopg2-binary)
-RUN python -m pip install --upgrade pip && \
+# Pre-build wheels for dependencies; leverage BuildKit cache for pip
+RUN --mount=type=cache,target=/root/.cache/pip \
+    python -m pip install --upgrade pip && \
     pip wheel --wheel-dir /wheels -r /app/requirements.txt
 
 FROM python:3.12-slim AS runtime


### PR DESCRIPTION
This pull request updates CI/CD workflow and Docker build processes to improve efficiency, caching, and maintainability. The most significant changes are improved Docker build caching, streamlined version extraction, and more robust workflow checkout logic.

**Docker build improvements:**

* Enhanced Docker build caching in `.github/workflows/prod-docker-publish.yml` by adding `cache-from` and `cache-to` options, limiting builds to `linux/amd64`, and setting build arguments for inline cache. Also, disabled provenance and SBOM generation for faster builds.
* Updated `Dockerfile` to use BuildKit pip cache during dependency installation, which speeds up builds by leveraging cached Python wheels.

**CI workflow enhancements:**

* Improved checkout logic in `.github/workflows/renovate.yml` to differentiate between `workflow_run` and manual triggers, ensuring the correct commit is checked out in each case.
* Simplified version extraction in `.github/workflows/prod-docker-publish.yml` by replacing the Python-based method with a more efficient `grep` command.

**Other workflow changes:**

* Removed the Python setup and production smoke test steps from the Docker publish workflow, likely because they are no longer necessary or handled elsewhere. [[1]](diffhunk://#diff-66e555341c67666cbb4e9644c0ca5bc0c6e343a127a9ce3f4f563ed44bf81d34L22-R26) [[2]](diffhunk://#diff-66e555341c67666cbb4e9644c0ca5bc0c6e343a127a9ce3f4f563ed44bf81d34L45-L55)