### PR TITLE
fix for renovate ci cd

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -21,11 +21,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
+
       - name: Checkout (manual)
-        if: ${{ github.event_name != 'workflow_run' }}
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         uses: actions/checkout@v4
+
       - name: Scan for critical vulnerabilities (Trivy)
-        if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'dev' }}
+        if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'dev' }}
         uses: aquasecurity/trivy-action@0.24.0
         with:
           scan-type: fs
@@ -35,10 +37,20 @@ jobs:
           exit-code: '1'
           format: table
           hide-progress: true
+
       - name: Self-hosted Renovate
+        if: >
+          ${{
+            (github.event_name == 'workflow_run' &&
+             github.event.workflow_run.conclusion == 'success' &&
+             github.event.workflow_run.event == 'push' &&
+             github.event.workflow_run.head_branch == 'dev')
+            || github.event_name == 'workflow_dispatch'
+          }}
         uses: renovatebot/github-action@v40.2.7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           configurationFile: renovate.json
         env:
           LOG_LEVEL: info
+          RENOVATE_REPOSITORIES: ${{ github.repository }}   # 👈 OVO DODAJ

--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
   "rangeStrategy": "auto",
   "rebaseWhen": "behind-base-branch",
   "pip_requirements": {
-    "fileMatch": ["(^|/)requirements\\.txt$"]
+    "managerFilePatterns": ["(^|/)requirements\\.txt$"]
   },
   "packageRules": [
     { "matchManagers": ["pip_requirements"], "groupName": "python dependencies" },


### PR DESCRIPTION
This pull request updates the Renovate workflow and configuration to improve how and when dependency updates and vulnerability scans are run. The changes ensure that jobs only run for the correct GitHub events and improve compatibility with newer Renovate configuration options.

**Workflow logic improvements:**

* Updated the conditions for the "Checkout (manual)" and "Scan for critical vulnerabilities (Trivy)" steps to ensure they only run for the intended GitHub events, preventing unnecessary or incorrect executions.
* Added a condition to the "Self-hosted Renovate" step so it runs only on successful pushes to the `dev` branch or when triggered manually, and set the `RENOVATE_REPOSITORIES` environment variable for better repository targeting.

**Renovate configuration update:**

* Changed the `pip_requirements` configuration in `renovate.json` to use `managerFilePatterns` instead of the deprecated `fileMatch` for better compatibility with recent Renovate versions.