### PR TITLE
renovate fix

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -50,7 +50,7 @@ jobs:
         uses: renovatebot/github-action@v43.0.4
 
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RENOVATE_TOKEN1 }}
           configurationFile: renovate-config.js
         env:
           LOG_LEVEL: info

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -47,10 +47,10 @@ jobs:
              github.event.workflow_run.head_branch == 'dev')
             || github.event_name == 'workflow_dispatch'
           }}
-        uses: renovatebot/github-action@v40.2.7
+        uses: renovatebot/github-action@v43.0.4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          configurationFile: renovate.json
+          configurationFile: renovate-config.js
         env:
           LOG_LEVEL: info
           RENOVATE_REPOSITORIES: ${{ github.repository }}   # 👈 OVO DODAJ

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -21,11 +21,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
+
       - name: Checkout (manual)
-        if: ${{ github.event_name != 'workflow_run' }}
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         uses: actions/checkout@v4
+
       - name: Scan for critical vulnerabilities (Trivy)
-        if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'dev' }}
+        if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'dev' }}
         uses: aquasecurity/trivy-action@0.24.0
         with:
           scan-type: fs
@@ -35,10 +37,20 @@ jobs:
           exit-code: '1'
           format: table
           hide-progress: true
+
       - name: Self-hosted Renovate
+        if: >
+          ${{
+            (github.event_name == 'workflow_run' &&
+             github.event.workflow_run.conclusion == 'success' &&
+             github.event.workflow_run.event == 'push' &&
+             github.event.workflow_run.head_branch == 'dev')
+            || github.event_name == 'workflow_dispatch'
+          }}
         uses: renovatebot/github-action@v40.2.7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           configurationFile: renovate.json
         env:
           LOG_LEVEL: info
+          RENOVATE_REPOSITORIES: ${{ github.repository }}   # 👈 OVO DODAJ

--- a/renovate-config.js
+++ b/renovate-config.js
@@ -1,0 +1,52 @@
+module.exports = {
+  platform: 'github',
+  endpoint: 'https://api.github.com/',
+  repositories: ['fsusak03/Vigar'],
+  onboarding: true,
+  onboardingConfig: {
+    extends: ['config:recommended', 'group:allNonMajor'],
+  },
+  dependencyDashboard: true,
+  baseBranches: ['dev'],
+  enabledManagers: [
+    'pip_requirements',
+    'dockerfile',
+    'docker-compose',
+    'github-actions',
+    // keep npm enabled for future JS tooling; harmless if no package.json
+    'npm'
+  ],
+  // Configure Python requirements.txt detection
+  pip_requirements: {
+    managerFilePatterns: ['(^|/)requirements\\.txt$']
+  },
+  packageRules: [
+    // Python: group and automerge patch/minor
+    {
+      matchManagers: ['pip_requirements'],
+      groupName: 'python dependencies',
+      matchUpdateTypes: ['patch', 'minor'],
+      automerge: true,
+    },
+    {
+      matchManagers: ['npm'],
+      matchUpdateTypes: ['patch', 'minor'],
+      automerge: true,
+    },
+    {
+      matchManagers: ['dockerfile'],
+      matchUpdateTypes: ['patch', 'minor'],
+      automerge: true,
+    },
+    {
+      matchManagers: ['docker-compose'],
+      matchUpdateTypes: ['patch', 'minor'],
+      automerge: true,
+    },
+    {
+      matchManagers: ['github-actions'],
+      matchUpdateTypes: ['patch', 'minor'],
+      automerge: true,
+    },
+  ],
+};

--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
   "rangeStrategy": "auto",
   "rebaseWhen": "behind-base-branch",
   "pip_requirements": {
-    "fileMatch": ["(^|/)requirements\\.txt$"]
+    "managerFilePatterns": ["(^|/)requirements\\.txt$"]
   },
   "packageRules": [
     { "matchManagers": ["pip_requirements"], "groupName": "python dependencies" },

--- a/renovate.json
+++ b/renovate.json
@@ -1,18 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
-  "dependencyDashboard": true,
-  "enabledManagers": ["pip_requirements", "dockerfile", "github-actions"],
-  "labels": ["dependencies"],
-  "prHourlyLimit": 0,
-  "rangeStrategy": "auto",
-  "rebaseWhen": "behind-base-branch",
-  "pip_requirements": {
-    "managerFilePatterns": ["(^|/)requirements\\.txt$"]
-  },
-  "packageRules": [
-    { "matchManagers": ["pip_requirements"], "groupName": "python dependencies" },
-    { "matchManagers": ["github-actions"], "groupName": "GitHub Actions" },
-    { "matchManagers": ["dockerfile"], "groupName": "Docker base images" }
-  ]
+  "extends": ["config:recommended"]
 }


### PR DESCRIPTION
This pull request updates the Renovate dependency management setup by switching from a JSON-based configuration (`renovate.json`) to a more flexible JavaScript-based configuration (`renovate-config.js`). It also upgrades the Renovate GitHub Action and changes the authentication token used. The new configuration allows for more granular control over dependency grouping and automerge behavior.

**Renovate configuration migration and improvements:**

* Migrated Renovate configuration from `renovate.json` to a new `renovate-config.js` file, enabling advanced configuration options such as grouping, automerge for patch/minor updates, and support for multiple managers including `pip_requirements`, `dockerfile`, `docker-compose`, `github-actions`, and `npm`. (`renovate-config.js`) [[1]](diffhunk://#diff-52607fc5a9cfd652e9b17b72fa13a14f484815cadfdf7ddee6ab9db9db78d954R1-R52) [[2]](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L3-R3)
* Removed most settings from `renovate.json`, leaving only the basic `extends` property, as all configuration is now handled in `renovate-config.js`. (`renovate.json`)

**Workflow and token updates:**

* Upgraded the Renovate GitHub Action from version `v40.2.7` to `v43.0.4` in the workflow file. (`.github/workflows/renovate.yml`)
* Changed the configuration file reference in the workflow from `renovate.json` to `renovate-config.js` and switched the authentication token from `GITHUB_TOKEN` to `RENOVATE_TOKEN1` for improved security and permissions. (`.github/workflows/renovate.yml`)